### PR TITLE
Ensure plugin works when vulnerability scanning is not enabled in Harbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ metadata:
 
 Everyone is welcome to contribute to this repository. Feel free to raise [issues](https://github.com/container-registry/backstage-plugin-harbor-backend/issues) or to submit [Pull Requests.](https://github.com/container-registry/backstage-plugin-harbor-backend/pulls)
 
+To test the plugin locally set environment variables APP_CONFIG_harbor_baseUrl, APP_CONFIG_harbor_username and APP_CONFIG_harbor_password. Run "yarn start" and access the endpoint at http://localhost:7007/artifacts?project={your-project-name}&repository={your-repo-name}
+
+
 ## History
 
 This Backstage plugin was initially created by [BESTSELLER](https://github.com/BESTSELLER) and transferred to us.

--- a/src/service/artifact.ts
+++ b/src/service/artifact.ts
@@ -33,35 +33,6 @@ export async function getArtifacts(
         push_time: string
         project_id: number
       }) => {
-        const vulnUrl: string = `${baseUrl}${element.addition_links.vulnerabilities.href}`
-
-        const vulns: Root = await fetch(vulnUrl, {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Basic ${Base64.encode(`${username}:${password}`)}`,
-          },
-        }).then((res: { json: () => any }) => res.json())
-
-        const vulnKey =
-          'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
-
-        if (vulns[vulnKey] === undefined) {
-          vulns[vulnKey] = {
-            generated_at: '',
-            scanner: {
-              name: 'undefined',
-              vendor: 'undefined',
-              version: 'undefined',
-            },
-            severity: 'Unknown',
-            vulnerabilities: [],
-          }
-        }
-
-        let severity = vulns[vulnKey].severity
-        if (severity === 'Unknown') {
-          severity = 'None'
-        }
 
         const projectId = element.project_id
         let critical = 0
@@ -69,34 +40,70 @@ export async function getArtifacts(
         let medium = 0
         let low = 0
         let none = 0
-
-        vulns[vulnKey].vulnerabilities.map((value) => {
-          switch (value.severity) {
-            case 'Low': {
-              low += 1
-              break
-            }
-            case 'Medium': {
-              medium += 1
-              break
-            }
-            case 'High': {
-              high += 1
-              break
-            }
-            case 'Critical': {
-              critical += 1
-              break
-            }
-            default:
-              none += 1
-          }
-        })
+        let severity = 'None'
+        let vulnerabilityCount = 0;
 
         const generatedTag = element.tags?.length
           ? element.tags[0].name
           : 'undefined'
 
+        if (element.addition_links.vulnerabilities !== undefined) {
+
+          const vulnUrl: string = `${baseUrl}${element.addition_links.vulnerabilities.href}`
+
+          const vulns: Root = await fetch(vulnUrl, {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Basic ${Base64.encode(`${username}:${password}`)}`,
+            },
+          }).then((res: { json: () => any }) => res.json())
+
+          const vulnKey =
+            'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
+
+          if (vulns[vulnKey] === undefined) {
+            vulns[vulnKey] = {
+              generated_at: '',
+              scanner: {
+                name: 'undefined',
+                vendor: 'undefined',
+                version: 'undefined',
+              },
+              severity: 'Unknown',
+              vulnerabilities: [],
+            }
+          }
+
+          severity = vulns[vulnKey].severity
+          if (severity === 'Unknown') {
+            severity = 'None'
+          }
+
+          vulns[vulnKey].vulnerabilities.map((value) => {
+            switch (value.severity) {
+              case 'Low': {
+                low += 1
+                break
+              }
+              case 'Medium': {
+                medium += 1
+                break
+              }
+              case 'High': {
+                high += 1
+                break
+              }
+              case 'Critical': {
+                critical += 1
+                break
+              }
+              default:
+                none += 1
+            }
+          })
+
+          vulnerabilityCount = Object.keys(vulns[vulnKey].vulnerabilities).length;
+        }
         const art: Artifact = {
           size: Math.round((element.size / 1028 / 1028) * 100) / 100,
           tag: generatedTag,
@@ -108,7 +115,7 @@ export async function getArtifacts(
             '%2F'
           )}`,
           vulnerabilities: {
-            count: Object.keys(vulns[vulnKey].vulnerabilities).length,
+            count: vulnerabilityCount,
             severity: severity,
             critical: critical,
             high: high,


### PR DESCRIPTION
When vulnerability scanning is not enabled, the JSON returned from Harbor does
not have an addition_links.vulnerabilities object. The plugin assumes this will
exist and returns an error.

Fix this by not populating the vulnerabilities section when this part of the
JSON is absent.